### PR TITLE
ReFactor the relevant code of the download directory

### DIFF
--- a/youtube-download.conf
+++ b/youtube-download.conf
@@ -35,10 +35,17 @@
 #  * Use $PLAYLIST to create one archive per playlist e.g. download_archive="/home/user/archives/$PLAYLIST.txt"
 #download_archive="$PLAYLIST.txt"
 
-# Filename or full path
-# Same youtube-dl -o
+# Set '/:dir%mpvconf%' to use mpv config directory to download
+# OR change to '/:dir%script%' for placing it in the same directory of script
+# OR change to '~~/ytdl/download' for sub-path of mpv portable_config directory
+# OR write any variable using '/:var', such as: '/:var%APPDATA%/mpv/ytdl/download' or '/:var%HOME%/mpv/ytdl/download'
+# OR specify the absolute path, such as: "C:\\Users\\UserName\\Downloads"
+#download_path=/:dir%mpvconf%/ytdl/download
+
+# Filename format to download file
 # see https://github.com/ytdl-org/youtube-dl/blob/master/README.md#output-template
-#filename=C:\Users\username\Downloads\%(title)s.%(ext)s
+# For example: "%(title)s.%(ext)s"
+#filename=%(title)s.%(ext)s
 
 # Use a cookies file for youtube-dl
 # Same as youtube-dl --cookies

--- a/youtube-download.lua
+++ b/youtube-download.lua
@@ -64,6 +64,7 @@ local opts = {
     -- OR change to '~~/ytdl/download' for sub-path of mpv portable_config directory
     -- OR write any variable using '/:var', such as: '/:var%APPDATA%/mpv/ytdl/download' or '/:var%HOME%/mpv/ytdl/download'
     -- OR specify the absolute path, such as: "C:\\Users\\UserName\\Downloads"
+    -- OR leave empty "" to use the current working directory
     download_path = "/:dir%mpvconf%/ytdl/download",
 
     -- Filename format to download file
@@ -210,7 +211,7 @@ elseif opts.download_path:match('^~~') then
 end
 
 --create opts.download_path if it doesn't exist
-if utils.readdir(opts.download_path) == nil then
+if not_empty(opts.download_path) and utils.readdir(opts.download_path) == nil then
     local is_windows = package.config:sub(1, 1) == "\\"
     local windows_args = { 'powershell', '-NoProfile', '-Command', 'mkdir', opts.download_path }
     local unix_args = { 'mkdir', opts.download_path }
@@ -302,7 +303,9 @@ local function download(download_type, config_file)
         mp.osd_message("Video download started", 2)
     end
 
-    opts.filename = opts.download_path .. "/" .. opts.filename
+    if not_empty(opts.download_path) then
+        opts.filename = opts.download_path .. "/" .. opts.filename
+    end
 
     -- Compose command line arguments
     local command = {}

--- a/youtube-download.lua
+++ b/youtube-download.lua
@@ -214,7 +214,7 @@ end
 if not_empty(opts.download_path) and utils.readdir(opts.download_path) == nil then
     local is_windows = package.config:sub(1, 1) == "\\"
     local windows_args = { 'powershell', '-NoProfile', '-Command', 'mkdir', opts.download_path }
-    local unix_args = { 'mkdir', opts.download_path }
+    local unix_args = { 'mkdir', '-p', opts.download_path }
     local args = is_windows and windows_args or unix_args
     local res = mp.command_native({name = "subprocess", capture_stdout = true, playback_only = false, args = args})
     if res.status ~= 0 then


### PR DESCRIPTION
ReFactor the relevant code of the download directory and create it automatically when the directory does not exist
Add a new option of download_path
Fix https://github.com/cvzi/mpv-youtube-download/issues/9