### PR TITLE
Configurable "Open terminal" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ mpv.com --msg-level=youtube_download=trace "https://www.youtube.com/watch?v=AbC_
 *   Cookies are picked up from `--ytdl-raw-options` or can be specified in the script configuration (disabled by default)
 *   A log file for youtube-dl download errors can be set in the in the script configuration (disabled by default)
 *   Choose between [youtube-dl](https://github.com/ytdl-org/youtube-dl/) or [yt-dlp](https://github.com/yt-dlp/yt-dlp). By default the script will try to auto-detect what is available and will prefer yt-dlp over youtube-dl. You can set the executable in the config to avoid the auto-detection.
-*   (Windows only) Donwload command can open a new terminal to monitor the download progress
+*   Download command can open a new terminal to monitor the download progress
 
 ## Credit
 - I pretty much copied the [mpv-youtube-quality](https://github.com/jgreco/mpv-youtube-quality) script

--- a/youtube-download.conf
+++ b/youtube-download.conf
@@ -102,9 +102,6 @@
 
 # Open a new "Windows Terminal" window/tab for download.
 # This allows you to monitor the download progress.
-# Currently only works on Windows with the new wt.exe terminal
-# If open_new_terminal_autoclose is yes, then the terminal window
-# will close after the download, even if there were errors
 # If mpv_playlist is true and the whole mpv playlist should be
 # downloaded, then all the downloads are scheduled immediately.
 # Before each download is scheduled, the script waits the given
@@ -113,8 +110,19 @@
 # can try to set the timeout to that value to avoid too many
 # parallel downloads.
 #open_new_terminal=no
-#open_new_terminal_autoclose=no
 #open_new_terminal_timeout=3
+
+# Set the command that opens a new terminal
+# Use "$cwd" as a placeholder for the working directory
+# Use "$cmd" as a placeholder for the download command
+# Example for xfce4-terminal that opens a tab `--tab`
+# and keeps the tab open `-H` after the download has finished
+#open_new_terminal_command=["xfce4-terminal", "--tab", "-H", "-x", "$cmd"]
+# Example for Windows Terminal that opens a tab `-new-tab` in a new window
+# called `ytdlp` and keeps the tab open `/K` after the download has finished.
+# Replace `/K` with `/C` to close the tab when the download has finished.
+open_new_terminal_command=["wt", "-w", "ytdlp", "new-tab", "-d", "$cwd", "cmd", "/K", "$cmd"]
+
 
 # Used to localize uosc-submenu content
 # Must use json format, example for Chinese: [{"Download": "下载","Audio": "音频"}]

--- a/youtube-download.conf
+++ b/youtube-download.conf
@@ -121,7 +121,7 @@
 # Example for Windows Terminal that opens a tab `-new-tab` in a new window
 # called `ytdlp` and keeps the tab open `/K` after the download has finished.
 # Replace `/K` with `/C` to close the tab when the download has finished.
-open_new_terminal_command=["wt", "-w", "ytdlp", "new-tab", "-d", "$cwd", "cmd", "/K", "$cmd"]
+#open_new_terminal_command=["wt", "-w", "ytdlp", "new-tab", "-d", "$cwd", "cmd", "/K", "$cmd"]
 
 
 # Used to localize uosc-submenu content

--- a/youtube-download.conf
+++ b/youtube-download.conf
@@ -100,7 +100,7 @@
 #download_subtitle_config_file=C:\Users\username\subtitle_config.txt
 #download_video_embed_subtitle_config_file=C:\Users\username\embeded_config.txt
 
-# Open a new "Windows Terminal" window/tab for download.
+# Open a new terminal window/tab for download.
 # This allows you to monitor the download progress.
 # If mpv_playlist is true and the whole mpv playlist should be
 # downloaded, then all the downloads are scheduled immediately.
@@ -112,7 +112,7 @@
 #open_new_terminal=no
 #open_new_terminal_timeout=3
 
-# Set the command that opens a new terminal
+# Set the command that opens a new terminal (JSON array)
 # Use "$cwd" as a placeholder for the working directory
 # Use "$cmd" as a placeholder for the download command
 # Example for xfce4-terminal that opens a tab `--tab`

--- a/youtube-download.lua
+++ b/youtube-download.lua
@@ -134,7 +134,7 @@ local opts = {
     -- Use "$cwd" as a placeholder for the working directory
     -- Use "$cmd" as a placeholder for the download command
     open_new_terminal_command = [[
-        ["xfce4-terminal", "--tab", "-H", "-x", "$cmd"]
+        ["wt", "-w", "ytdlp", "new-tab", "-d", "$cwd", "cmd", "/K", "$cmd"]
     ]],
 
     -- Used to localize uosc-submenu content

--- a/youtube-download.lua
+++ b/youtube-download.lua
@@ -130,9 +130,10 @@ local opts = {
     -- timeout in seconds
     open_new_terminal = true,
     open_new_terminal_timeout = 3,
-    -- Set the command that opens a new terminal
+    -- Set the command that opens a new terminal (JSON array)
     -- Use "$cwd" as a placeholder for the working directory
     -- Use "$cmd" as a placeholder for the download command
+    -- See .conf file for Windows and xfce examples.
     open_new_terminal_command = [[
         ["wt", "-w", "ytdlp", "new-tab", "-d", "$cwd", "cmd", "/K", "$cmd"]
     ]],

--- a/youtube-download.lua
+++ b/youtube-download.lua
@@ -122,18 +122,20 @@ local opts = {
     download_subtitle_config_file = "",
     download_video_embed_subtitle_config_file= "",
 
-    -- Open a new "Windows Terminal" window/tab for download
+    -- Open a new terminal window/tab for download
     -- This allows you to monitor the download progress
-    -- Currently only works on Windows with the new wt terminal
-    -- If open_new_terminal_autoclose is true, then the terminal window
-    -- will close after the download, even if there were errors
     -- If mpv_playlist is true and the whole mpv playlist should be
     -- downloaded, then all the downloads are scheduled immediately.
     -- Before each download is started, the script waits the given
     -- timeout in seconds
-    open_new_terminal = false,
-    open_new_terminal_autoclose = false,
+    open_new_terminal = true,
     open_new_terminal_timeout = 3,
+    -- Set the command that opens a new terminal
+    -- Use "$cwd" as a placeholder for the working directory
+    -- Use "$cmd" as a placeholder for the download command
+    open_new_terminal_command = [[
+        ["xfce4-terminal", "--tab", "-H", "-x", "$cmd"]
+    ]],
 
     -- Used to localize uosc-submenu content
     -- Must use json format, example for Chinese: [{"Download": "下载","Audio": "音频"}]
@@ -209,6 +211,9 @@ end
 
 --Read text string
 local locale_content = utils.parse_json(opts.locale_content)
+local open_new_terminal_command = utils.parse_json(opts.open_new_terminal_command)
+
+local is_windows = package.config:sub(1, 1) == "\\"
 
 local function locale(str)
     if str and locale_content then
@@ -266,7 +271,6 @@ end
 
 --create opts.download_path if it doesn't exist
 if not_empty(opts.download_path) and utils.readdir(opts.download_path) == nil then
-    local is_windows = package.config:sub(1, 1) == "\\"
     local windows_args = { 'powershell', '-NoProfile', '-Command', 'mkdir', string.format("\"%s\"", opts.download_path) }
     local unix_args = { 'mkdir', '-p', opts.download_path }
     local args = is_windows and windows_args or unix_args
@@ -943,37 +947,50 @@ local function download(download_type, config_file, overwrite_opts)
 
         -- Check working directory is writable (in case the filename does not specify a directory)
         local cwd = utils.getcwd()
-        local win_programs = "C:\\Program Files"
-        local win_win = "C:\\Windows"
-        if cwd:lower():sub(1, #win_programs) == win_programs:lower() or cwd:lower():sub(1, #win_win) == win_win:lower() then
-           msg.debug("The mpv working directory ('" ..cwd .."') is probably not writable. Trying %USERPROFILE%...")
-           local user_profile = os.getenv("USERPROFILE")
-           if  user_profile ~= nil then
-                cwd = user_profile
-           else
-                msg.warn("open_new_terminal is enabled, but %USERPROFILE% is not defined")
-                mp.osd_message("open_new_terminal is enabled, but %USERPROFILE% is not defined", 3)
-           end
+        local has_cwd = false
+        for _, value in pairs(open_new_terminal_command) do
+            if value == "$cwd" then
+                has_cwd = true
+                break
+            end
+        end
+        if has_cwd then
+            local win_programs = "C:\\Program Files"
+            local win_win = "C:\\Windows"
+            if cwd:lower():sub(1, #win_programs) == win_programs:lower() or cwd:lower():sub(1, #win_win) == win_win:lower() then
+                msg.debug("The mpv working directory ('" ..cwd .."') is probably not writable. Trying %USERPROFILE%...")
+                local user_profile = os.getenv("USERPROFILE")
+                if  user_profile ~= nil then
+                        cwd = user_profile
+                else
+                        msg.warn("open_new_terminal is enabled, but %USERPROFILE% is not defined")
+                        mp.osd_message("open_new_terminal is enabled, but %USERPROFILE% is not defined", 3)
+                end
+            end
         end
 
         -- Escape restricted characters on Windows
-        local restricted = "&<>|"
-        for key, value in ipairs(command) do
-            command[key] = value:gsub("["..  restricted .. "]", "^%0")
+        if is_windows then
+            local restricted = "&<>|"
+            for key, value in ipairs(command) do
+                command[key] = value:gsub("["..  restricted .. "]", "^%0")
+            end
         end
 
-        -- Prepend command with wt.exe
-        table.insert(command, 1, "wt")
-        table.insert(command, 2, "-w")
-        table.insert(command, 3, "ytdlp")
-        table.insert(command, 4, "new-tab")
-        table.insert(command, 5, "-d")
-        table.insert(command, 6, cwd)
-        table.insert(command, 7, "cmd")
-        if opts.open_new_terminal_autoclose then
-            table.insert(command, 8, "/C")
-        else
-            table.insert(command, 8, "/K")
+        -- Prepend command with open_new_terminal_command
+        local i = 1
+        local inserted_cmd = false
+        for _, value in pairs(open_new_terminal_command) do
+            if value == "$cwd" then
+                table.insert(command, i, cwd)
+            elseif value == "$cmd" then
+                inserted_cmd = true
+            elseif inserted_cmd then
+                table.insert(command, value) -- append after command
+            else
+                table.insert(command, i, value) -- prepend before command
+            end
+            i = i + 1
         end
         msg.debug("exec (async): " .. table.concat(command, " "))
     end


### PR DESCRIPTION
Adds a new option to customize the command that opens a new terminal.

```ini
# xfce
open_new_terminal_command=["xfce4-terminal", "--tab", "-H", "-x", "$cmd"]
# windows terminal
open_new_terminal_command=["wt", "-w", "ytdlp", "new-tab", "-d", "$cwd", "cmd", "/K", "$cmd"]
```



Closes #28